### PR TITLE
Remove TL;DR

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,3 @@
 The Swiftiest way to parse JSON... Use `guard` and `as?`.
 
 For debugging, use `print` or breakpoints.
-
-TL;DR: Use `guard` and `as?`.


### PR DESCRIPTION
Brevity is a hallmark of true Swiftiness. By removing duplicated information in the TL;DR, the library could be slimmed by ~~50%~~ 33%. This change would greatly reduce cognitive overhead for developers. I hope you'll give this serious consideration.
